### PR TITLE
Feature/using interactables

### DIFF
--- a/Brackeys2024-1/Assets/BasicMaterials/M_Lit_Green.mat
+++ b/Brackeys2024-1/Assets/BasicMaterials/M_Lit_Green.mat
@@ -108,8 +108,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 1
     m_Colors:
-    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _BaseColor: {r: 0.15873651, g: 0.8207547, b: 0.07355818, a: 1}
+    - _Color: {r: 0.15873651, g: 0.8207547, b: 0.07355818, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.2, g: 0.2, b: 0.2, a: 1}
   m_BuildTextureStacks: []

--- a/Brackeys2024-1/Assets/Core/InteractComponent.cs
+++ b/Brackeys2024-1/Assets/Core/InteractComponent.cs
@@ -1,32 +1,78 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using Unity.Collections;
+using UnityEditor;
 using UnityEngine;
 
+[Serializable]
+public struct CombinationKey
+{
+    public string InteractID;
+    
+    [Tooltip("READ ONLY. Is set at runtime, default = false.")]
+    public bool IsCombined;
+}
+[RequireComponent(typeof(Rigidbody))]
 public class InteractComponent : MonoBehaviour
 {
-    //The 
-    public string InteractID;
-    [ReadOnly]
-    public bool IsHeld = false;
-    public SocketComponent IsSocketedBy;
+    public string InteractID => this.gameObject.name;
     private Rigidbody _rigidbody;
+    [Header("Holding")]
+    public bool CanBeHeld;
+    public PlayerInteractionComponent IsHeldBy;
+    
+    [Header("Socketing")]
+    public SocketComponent IsSocketedBy;
+    
+    [Header("Usage")]
+    [Tooltip("The InteractIDs that this object can be used on/Combined with.")]
+    public List<CombinationKey> ValidCombinationKeys;
+    public bool CanBeUsedWithoutCombination;
+    public bool DestroyOnUse;
+
+    //Called when an interactable is used (Self or on a target).
+    //@Param string = this.InteractID
+    public static event Action<string> OnInteractUsed;
+    //Called when an interactable is used on this.
+    //@Param string = this.InteractID
+    //@Param string = other.InteractID
+    public static event Action<string, string> OnValidInteractUsed;
+    //Called when all objects in ValidCombinations have been met
+    //@Param string = this.InteractID
+    public static event Action<string> OnInteractKeysComplete;
     
     // Start is called before the first frame update
     void Awake()
     {
         _rigidbody = GetComponent<Rigidbody>();
     }
+    
+    public void HoldUpdate(Transform holdOrigin, Rigidbody holdRigidbody, float gravityStrength, AnimationCurve gravityDistanceCurve, float rotationSpeed)
+    {
+        Vector3 directionToOrigin = holdOrigin.position - transform.position;
+        Vector3 relativeVelocity = holdRigidbody.GetComponent<PlayerMovementComponent>().Velocity - _rigidbody.velocity;
+
+        Vector3 movementStep = directionToOrigin.normalized * ((gravityStrength * gravityDistanceCurve.Evaluate(directionToOrigin.magnitude)) * directionToOrigin.magnitude);
+        
+        _rigidbody.velocity += movementStep + relativeVelocity;
+        
+        // Smoothly rotate towards the target rotation
+        transform.rotation = Quaternion.Slerp(transform.rotation, holdOrigin.rotation, rotationSpeed * Time.fixedDeltaTime);
+    }
 
     public bool CanBePickedUp()
     {
-        //TODO Implement
-        return true;
+        return CanBeHeld;
     }
 
-    public void ToggleIsHeld(bool toggle)
+    public void ToggleIsHeld(bool toggle, PlayerInteractionComponent isHeldBy=null)
     {
-        IsHeld = toggle;
+        if (IsSocketedBy)
+        {
+            RemoveFromSocket();
+        }
+        IsHeldBy = isHeldBy;
         _rigidbody.useGravity = !toggle;
     }
 
@@ -37,17 +83,125 @@ public class InteractComponent : MonoBehaviour
         _rigidbody.useGravity = false;
     }
 
-    public void HoldUpdate(Transform holdOrigin, Rigidbody holdRigidbody, float gravityStrength, AnimationCurve gravityDistanceCurve, float rotationSpeed)
+    public void RemoveFromSocket()
     {
-        Vector3 directionToOrigin = holdOrigin.position - transform.position;
-        Vector3 relativeVelocity = holdRigidbody.GetComponent<PlayerMovementComponent>().Velocity - _rigidbody.velocity;
+        IsSocketedBy = null;
+    }
+    
+    public virtual bool Interact(InteractComponent focus)
+    {
+        if (focus)
+        {
+            //This item is trying to be used on another item
+            if (IsValidCombination(focus))
+            { 
+                Use(focus);
+            }
+        }
+        else
+        {
+            //This item is trying to be used on nothing
+            
+            if (CanBeUsedWithoutCombination)
+            {
+                Use(null);
+                return true;
+            }
+            else
+            {
+                //Drop Item
+                ToggleIsHeld(false);
+            }
+            return false;
+        }
 
-        Vector3 movementStep = directionToOrigin.normalized * ((gravityStrength * gravityDistanceCurve.Evaluate(directionToOrigin.magnitude)) * directionToOrigin.magnitude);
-        
-        _rigidbody.velocity += movementStep + relativeVelocity;
-        
+        return false;
+    }
 
-        // Smoothly rotate towards the target rotation
-        transform.rotation = Quaternion.Slerp(transform.rotation, holdOrigin.rotation, rotationSpeed * Time.fixedDeltaTime);
+    private bool IsValidCombination(InteractComponent otherComponent)
+    {
+        for (int i = 0; i < ValidCombinationKeys.Count; i++)
+        {
+            if (ValidCombinationKeys[i].InteractID == otherComponent.InteractID)
+            {
+                //Update Key
+                CombinationKey tempKey = ValidCombinationKeys[i];
+                tempKey.IsCombined = true;
+                ValidCombinationKeys[i] = tempKey;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public virtual bool Use(InteractComponent focusTarget=null)
+    {
+        (bool, bool) successAndDestroy = (false, true);
+        
+        if (focusTarget)
+        {
+            successAndDestroy = focusTarget.UsedOnThis(this);
+        }
+        else
+        {
+            successAndDestroy = (CanBeUsedWithoutCombination, DestroyOnUse);
+        }
+        
+        //Was usage successful?
+        if (successAndDestroy.Item1)
+        {
+            Debug.Log($"{InteractID} was used on {(focusTarget ? focusTarget.InteractID : "self")}{(successAndDestroy.Item2 ? ":Destroying" : "")}");
+            OnUse(successAndDestroy.Item2);
+        }
+
+        return (successAndDestroy.Item2);
+    }
+
+    public (bool, bool) UsedOnThis(InteractComponent componentBeingUsed)
+    {
+        bool success = false;
+        //TODO Implement, sometimes things won't want to be destroyed.
+        bool destroyOnSuccess = componentBeingUsed.DestroyOnUse;
+        success = IsValidCombination(componentBeingUsed);
+        if (success)
+        {
+            OnValidInteractUsed?.Invoke(InteractID, componentBeingUsed.InteractID);
+
+            if (AreAllKeysCombined())
+            {
+                Debug.Log($"All Keys are complete on {InteractID}");
+                OnInteractKeysComplete?.Invoke(InteractID);
+            }
+        }
+        return (success, destroyOnSuccess);
+    }
+
+    private bool AreAllKeysCombined()
+    {
+        foreach (CombinationKey key in ValidCombinationKeys)
+        {
+            if (!key.IsCombined)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public virtual void OnUse(bool destroyOnUse)
+    {
+        OnInteractUsed?.Invoke(InteractID);
+
+        //Does it need to be destroyed?
+        if (destroyOnUse)
+        {
+            if (IsHeldBy is not null)
+            {
+                IsHeldBy.currentlyHoldingObject = null;
+            }
+            Destroy(gameObject);
+        }
     }
 }

--- a/Brackeys2024-1/Assets/Core/InteractComponent.cs
+++ b/Brackeys2024-1/Assets/Core/InteractComponent.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 
 public class InteractComponent : MonoBehaviour
 {
+    //The 
+    public string InteractID;
     [ReadOnly]
     public bool IsHeld = false;
     private Rigidbody _rigidbody;

--- a/Brackeys2024-1/Assets/Core/InteractComponent.cs
+++ b/Brackeys2024-1/Assets/Core/InteractComponent.cs
@@ -9,6 +9,7 @@ public class InteractComponent : MonoBehaviour
     public string InteractID;
     [ReadOnly]
     public bool IsHeld = false;
+    public SocketComponent IsSocketedBy;
     private Rigidbody _rigidbody;
     
     // Start is called before the first frame update
@@ -29,6 +30,13 @@ public class InteractComponent : MonoBehaviour
         _rigidbody.useGravity = !toggle;
     }
 
+    public void AddToSocket(SocketComponent socket)
+    {
+        ToggleIsHeld(false);
+        IsSocketedBy = socket;
+        _rigidbody.useGravity = false;
+    }
+
     public void HoldUpdate(Transform holdOrigin, Rigidbody holdRigidbody, float gravityStrength, AnimationCurve gravityDistanceCurve, float rotationSpeed)
     {
         Vector3 directionToOrigin = holdOrigin.position - transform.position;
@@ -41,7 +49,5 @@ public class InteractComponent : MonoBehaviour
 
         // Smoothly rotate towards the target rotation
         transform.rotation = Quaternion.Slerp(transform.rotation, holdOrigin.rotation, rotationSpeed * Time.fixedDeltaTime);
-
-
     }
 }

--- a/Brackeys2024-1/Assets/Core/Player/Player.prefab
+++ b/Brackeys2024-1/Assets/Core/Player/Player.prefab
@@ -244,8 +244,8 @@ MonoBehaviour:
     m_RotationOrder: 4
   gravityStrength: 10
   rotationSpeed: 5
-  focusRadius: 0.1
-  focusRange: 1.2
+  focusRadius: 0.5
+  focusRange: 2
 --- !u!1 &7488077641275484621
 GameObject:
   m_ObjectHideFlags: 0

--- a/Brackeys2024-1/Assets/Core/Player/PlayerInteractionComponent.cs
+++ b/Brackeys2024-1/Assets/Core/Player/PlayerInteractionComponent.cs
@@ -67,9 +67,9 @@ public class PlayerInteractionComponent : MonoBehaviour
     //Physics Calculations go in Fixed Update
     void FixedUpdate()
     {
-        if (currentlyHoldingObject && currentlyHoldingObject.IsHeld)
+        if (currentlyHoldingObject)
         {
-            if (currentlyHoldingObject.IsHeld)
+            if (currentlyHoldingObject.IsHeldBy == this)
             {
                 currentlyHoldingObject.HoldUpdate(holdTransform, _rigidbody, gravityStrength, gravityDistanceCurve, rotationSpeed);
             }
@@ -113,11 +113,10 @@ public class PlayerInteractionComponent : MonoBehaviour
     {
         if (currentlyHoldingObject is not null)
         {
-            //TODO Use object on valid Focus
-            
-            //OR drop the item
-            currentlyHoldingObject.ToggleIsHeld(false);
-            currentlyHoldingObject = null;
+            if (currentlyHoldingObject.Interact(currentFocus))
+            {
+                currentlyHoldingObject = null;
+            }
         }
         else if(currentFocus)
         {
@@ -125,7 +124,7 @@ public class PlayerInteractionComponent : MonoBehaviour
             if (currentFocus.CanBePickedUp())
             {
                 currentlyHoldingObject = currentFocus;
-                currentlyHoldingObject.ToggleIsHeld(true);
+                currentlyHoldingObject.ToggleIsHeld(true, this);
             }
         }
     }

--- a/Brackeys2024-1/Assets/Core/Player/PlayerInteractionComponent.cs
+++ b/Brackeys2024-1/Assets/Core/Player/PlayerInteractionComponent.cs
@@ -67,10 +67,18 @@ public class PlayerInteractionComponent : MonoBehaviour
     //Physics Calculations go in Fixed Update
     void FixedUpdate()
     {
-        if (currentlyHoldingObject)
+        if (currentlyHoldingObject && currentlyHoldingObject.IsHeld)
         {
-            currentlyHoldingObject.HoldUpdate(holdTransform, _rigidbody, gravityStrength, gravityDistanceCurve, rotationSpeed);
+            if (currentlyHoldingObject.IsHeld)
+            {
+                currentlyHoldingObject.HoldUpdate(holdTransform, _rigidbody, gravityStrength, gravityDistanceCurve, rotationSpeed);
+            }
+            else
+            {
+                currentlyHoldingObject = null;
+            }
         }
+        
     }
 
     //Raycasts from the origin and checks to see if any objects that can interacted with. Then chooses the primary target. Will always choose closest/First

--- a/Brackeys2024-1/Assets/Core/VideoComponent.cs
+++ b/Brackeys2024-1/Assets/Core/VideoComponent.cs
@@ -54,12 +54,10 @@ public class VideoComponent : MonoBehaviour
     private VideoPlayer _videoPlayer;
     private AudioSource _audioSource;
 
-    private void OnEnable()
+    void Start()
     {
-    }
-
-    private void OnDisable()
-    {
+        //TODO Hook up the game start @Jeremy!
+        OnStart();
     }
 
     // Start is called before the first frame update
@@ -171,6 +169,7 @@ public class VideoComponent : MonoBehaviour
         CancelInvoke(nameof(OnVideoFinished));
     }
 
+    //TODO Hook up to Game.cs pause. @jeremy!
     void OnGamePause(bool isPaused)
     {
         if (isPaused)

--- a/Brackeys2024-1/Assets/Room1/R1Canvas.prefab
+++ b/Brackeys2024-1/Assets/Room1/R1Canvas.prefab
@@ -1,0 +1,137 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4039032155010159592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4039032155010159573}
+  - component: {fileID: 4039032155010159593}
+  - component: {fileID: 4039032155010159572}
+  - component: {fileID: 4039032155010159595}
+  - component: {fileID: 4039032155010159594}
+  - component: {fileID: 4039032155010159574}
+  m_Layer: 0
+  m_Name: R1Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4039032155010159573
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.05, y: 1, z: 0.7}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &4039032155010159593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 05098ad76dbd1f94395997ef47b14197, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CanBeHeld: 0
+  IsHeldBy: {fileID: 0}
+  IsSocketedBy: {fileID: 0}
+  ValidCombinationKeys:
+  - InteractID: R1Paint
+    IsCombined: 0
+  CanBeUsedWithoutCombination: 0
+  DestroyOnUse: 0
+--- !u!33 &4039032155010159572
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4039032155010159595
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4039032155010159594
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &4039032155010159574
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4039032155010159592}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Brackeys2024-1/Assets/Room1/R1Canvas.prefab.meta
+++ b/Brackeys2024-1/Assets/Room1/R1Canvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ba444a5765ca56945a10032a47b53e7b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Brackeys2024-1/Assets/Room1/R1Paint.prefab
+++ b/Brackeys2024-1/Assets/Room1/R1Paint.prefab
@@ -1,0 +1,138 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8744541435329001843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8744541435329001844}
+  - component: {fileID: 8744541435329001840}
+  - component: {fileID: 8744541435329001847}
+  - component: {fileID: 8744541435329001846}
+  - component: {fileID: 8744541435329001841}
+  - component: {fileID: 8744541435329001845}
+  m_Layer: 0
+  m_Name: R1Paint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8744541435329001844
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.17919517, y: 0.17919517, z: 0.17919517}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8744541435329001840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 05098ad76dbd1f94395997ef47b14197, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CanBeHeld: 1
+  IsHeldBy: {fileID: 0}
+  IsSocketedBy: {fileID: 0}
+  ValidCombinationKeys:
+  - InteractID: R1Canvas
+    IsCombined: 0
+  CanBeUsedWithoutCombination: 0
+  DestroyOnUse: 1
+--- !u!33 &8744541435329001847
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  m_Mesh: {fileID: 10206, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8744541435329001846
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 5a9110534f30d0a4fb90f29b31d262ae, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!136 &8744541435329001841
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5000001
+  m_Height: 2
+  m_Direction: 1
+  m_Center: {x: 0.000000059604645, y: 0, z: -0.00000008940697}
+--- !u!54 &8744541435329001845
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8744541435329001843}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Brackeys2024-1/Assets/Room1/R1Paint.prefab.meta
+++ b/Brackeys2024-1/Assets/Room1/R1Paint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f661f0d977ac2ab49a74653e43d25308
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Objects are required to have InteractComponent for interaction.

Properties should be pretty self-explanatory, @Kris socketing is very minimalistic, feel free to alter this to your needs.

If you want the object to be usable on its own, then ignore ValidCombinationKeys and tick CanBeUsedWithoutCombination. Otherwise to use it with another object, add an element to the list, and set the InteractID, this is the gameObject.name you wish to combine with. Do the same for the the other component.

Example (In-game): A paint bucket and canvas, you want to use the paintbucket on the canvas.
Add InteractComponent to both objects.
On The Canvas
To CombinationKeys add the Paintbucket's name (R1Canvas).
On The PaintBucket
To CombinationKeys add the Canvas's name (R1Paint).
Tick CanBeHeld and DestroyOnUse.
Play the game
Pickup the paint with LMB
Look at the canvas, press LMB, and voila, you used it on the canvas.
Events will run at this point, of which you can find in InteractComponent.cs.

Play around with different variables to suit your needs. 
 
Need a TV Remote? Tick CanBeHeld, CanBeUsedWithoutCombination, then listen for InteractComponent.OnInteractUsed("TVRemote").